### PR TITLE
ERM-86 Contacts appear blank when reporting issues if name is empty

### DIFF
--- a/organizations/admin/classes/domain/Organization.php
+++ b/organizations/admin/classes/domain/Organization.php
@@ -337,7 +337,7 @@ class Organization extends DatabaseObject {
 	public function getExportableIssues($archivedOnly=false){
 		$orgDB = $this->db->config->database->name;
 		$resourceDB = $this->db->config->settings->resourcesDatabaseName;
-		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT(sc.name,' - ',sc.emailAddress) SEPARATOR ', ')
+		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT('=HYPERLINK(\"mailto:',sc.emailAddress,'\",\"',COALESCE(sc.name,sc.emailAddress),'\")') SEPARATOR ', ')
 								FROM `{$resourceDB}`.IssueContact sic
 								LEFT JOIN `{$orgDB}`.Contact sc ON sc.contactID=sic.contactID
 								WHERE sic.issueID=i.issueID) AS `contacts`,

--- a/organizations/ajax_forms.php
+++ b/organizations/ajax_forms.php
@@ -613,7 +613,12 @@ switch ($_GET['action']) {
 <?php
 
 		foreach ($organizationContactsArray as $contact) {
-			echo "		<option value=\"{$contact->contactID}\">{$contact->name}</option>";
+			$contactname = ($contact->name);
+				if (!empty($contactname)) {
+					echo "		<option value=\"{$contact->contactID}\">{$contact->name}</option>";
+				} else {
+					echo "		<option value=\"{$contact->contactID}\">{$contact->emailAddress}</option>";
+				}
 		}
 
 ?>

--- a/organizations/ajax_htmldata.php
+++ b/organizations/ajax_htmldata.php
@@ -48,7 +48,11 @@ function generateIssueHTML($issue,$associatedEntities=null) {
 	if ($contacts) {
 		$html .= "<ul class=\"contactList\">";
 		foreach($contacts as $contact) {
-			$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['name']}</a></li>";
+			if(!empty($contact['name'])) {
+				$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['name']}</a></li>";
+			} else {
+				$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['emailAddress']}</a></li>";
+			}
 		}
 		$html .= "</ul>";
 	}

--- a/organizations/css/style.css
+++ b/organizations/css/style.css
@@ -2041,12 +2041,12 @@ table.titleTable {
 	overflow-x: hidden !important;
 }
 
-/*--- Add space before and after each downtime definition ---*/
+/*--- Add space before and after each issue and downtime definition ---*/
 
 dt:first-child {
     padding-top: .5em;
 }
 
-div.downtime {
+div.downtime, div.issue {
     padding-bottom: 1em;
 }

--- a/resources/admin/classes/domain/Organization.php
+++ b/resources/admin/classes/domain/Organization.php
@@ -108,7 +108,7 @@ class Organization extends DatabaseObject {
 			$orgField = 'shortName';
 		}
 
-		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT(sc.name,' - ',sc.emailAddress) SEPARATOR ', ')
+		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT('=HYPERLINK(\"mailto:',sc.emailAddress,'\",\"',COALESCE(sc.name,sc.emailAddress),'\")') SEPARATOR ', ')
 								FROM IssueContact sic
 								LEFT JOIN `{$orgDB}`.Contact sc ON sc.contactID=sic.contactID
 								WHERE sic.issueID=i.issueID) AS `contacts`,

--- a/resources/admin/classes/domain/Resource.php
+++ b/resources/admin/classes/domain/Resource.php
@@ -395,7 +395,7 @@ class Resource extends DatabaseObject {
 			$contactsDB = $this->db->config->database->name;
 		}
 
-		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT(sc.name,' - ',sc.emailAddress) SEPARATOR ', ')
+		$query = "SELECT i.*,(SELECT GROUP_CONCAT(CONCAT('=HYPERLINK(\"mailto:',sc.emailAddress,'\",\"',COALESCE(sc.name,sc.emailAddress),'\")') SEPARATOR ', ')
 								FROM IssueContact sic
 								LEFT JOIN `{$contactsDB}`.Contact sc ON sc.contactID=sic.contactID
 								WHERE sic.issueID=i.issueID) AS `contacts`,

--- a/resources/ajax_forms/getNewIssueForm.php
+++ b/resources/ajax_forms/getNewIssueForm.php
@@ -42,7 +42,11 @@ if ($organizationData['organizationID']) {
 <?php
 
 	foreach ($contactsArray as $contact) {
-		echo "		<option value=\"{$contact['contactID']}\">{$contact['name']}</option>";
+		if (!empty($contact['name'])) {
+			echo "		<option value=\"{$contact['contactID']}\">{$contact['name']}</option>";
+		} else {
+			echo "		<option value=\"{$contact['contactID']}\">{$contact['emailAddress']}</option>";
+		}
 	}
 
 ?>

--- a/resources/ajax_htmldata/getIssuesList.php
+++ b/resources/ajax_htmldata/getIssuesList.php
@@ -39,7 +39,11 @@ function generateIssueHTML($issue,$associatedEntities=null) {
 	if ($contacts) {
 		$html .= "<ul class=\"contactList\">";
 		foreach($contacts as $contact) {
-			$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['name']}</a></li>";
+			if (!empty($contact['name'])) {
+				$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['name']}</a></li>";
+			} else {
+				$html .= "<li><a href=\"mailto:".urlencode($contact['emailAddress'])."?Subject=RE: {$issue->subjectText}\">{$contact['emailAddress']}</a></li>";
+			}
 		}
 		$html .= "</ul>";
 	}

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -3273,12 +3273,12 @@ input#archiveInd {
     margin-bottom: 10px;
 }
 
-/*--- Add space before and after each downtime definition ---*/
+/*--- Add space before and after each issue and downtime definition ---*/
 
 dt:first-child {
     padding-top: .5em;
 }
 
-div.downtime {
+div.downtime, div.issue {
     padding-bottom: 1em;
 }


### PR DESCRIPTION
Reported by a SirsiDynix customer: when reporting a new issue for a resource or organization, contacts are shown as blank values when the contact has no name. It would be preferable to show the email address when there is no name.

These are relatively simple changes that ought not adversely affect anyone who is content with the current functionality.

It's perhaps a moot point whether it's good practice to enter contacts without a name although I note the name field is not strictly required.